### PR TITLE
Fix handling of live photos on iOS

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -1045,6 +1045,10 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                 }];
             } else if ([provider canLoadObjectOfClass:[UIImage class]]) {
                 NSString *identifier = provider.registeredTypeIdentifiers.firstObject;
+                if ([identifier isEqualToString:@"com.apple.live-photo-bundle"]) {
+                    // Handle live photos
+                    identifier = @"public.jpeg";
+                }
                 [provider loadFileRepresentationForTypeIdentifier:identifier
                                                 completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
                     [lock lock];


### PR DESCRIPTION
Testing on iOS 14, it looks like simply taking the first element of the `registeredTypeIdentifiers` could result in `com.apple.live-photo-bundle` being returned. In the array there were 3 elements:

[0] `com.apple.live-photo-bundle`
[1] `public.jpeg`
[2] `public.heic`

Overriding the `identifier` to `public.jpeg` seems to fix this.