### PR TITLE
Fix PHPickerViewController non-main thread crash on iOS15

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -256,10 +256,10 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
 
     if (@available(iOS 14, *)) {
         if (![self.options[@"cropperCircleOverlay"] boolValue] && ![self.options[@"cropping"] boolValue]) {
-            PHPickerConfiguration *configuration = [self makeConfiguration];
-            PHPickerViewController *controller = [[PHPickerViewController alloc] initWithConfiguration:configuration];
-            controller.delegate = self;
             dispatch_async(dispatch_get_main_queue(), ^{
+                PHPickerConfiguration *configuration = [self makeConfiguration];
+                PHPickerViewController *controller = [[PHPickerViewController alloc] initWithConfiguration:configuration];
+                controller.delegate = self;
                 [[self getRootVC] presentViewController:controller animated:YES completion:nil];
             });
             return;


### PR DESCRIPTION
This should fix the crash when trying to open the picker on iOS15